### PR TITLE
Fix DeleteAsync to return Task instead of Void

### DIFF
--- a/src/Stripe/Services/Cards/StripeCardService.cs
+++ b/src/Stripe/Services/Cards/StripeCardService.cs
@@ -109,7 +109,7 @@ namespace Stripe
             );
         }
 
-        public virtual async void DeleteAsync(string customerOrRecipientId, string cardId, bool isRecipient = false, StripeRequestOptions requestOptions = null)
+        public virtual async Task DeleteAsync(string customerOrRecipientId, string cardId, bool isRecipient = false, StripeRequestOptions requestOptions = null)
         {
             var url = SetupUrl(customerOrRecipientId, isRecipient, cardId);
 


### PR DESCRIPTION
Generally async void methods are reserved for event handlers.

For instance public virtual void Delete method in StripeCardService class is not awaitable since it returns void instead of a Task.

This may cause the following run time error. [InvalidOperationException: An asynchronous module or handler completed while an asynchronous operation was still pending.]
